### PR TITLE
Add timeout support to NordusRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ const instance = create(
 );
 ```
 
+You can add timeout on each request.
+
+```js
+try {
+  await get("http://localhost:5000/todos/1", {
+    timeout: 100,
+  });
+  expect(true).toBeFalsy();
+} catch (error) {
+  expect(error.message).toEqual("The operation was aborted. ");
+}
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/tests/get.spec.ts
+++ b/tests/get.spec.ts
@@ -12,6 +12,7 @@ describe("interceptors", () => {
       responseType: "blob",
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(response.data)).toEqual(String(new Blob(["test"])));
   });
 

--- a/tests/timeout.spec.ts
+++ b/tests/timeout.spec.ts
@@ -1,0 +1,26 @@
+import { get } from "../src";
+import { FetchMock } from "jest-fetch-mock";
+
+describe("timeout", () => {
+  const fetchMock = fetch as FetchMock;
+  beforeAll(() => fetchMock.enableMocks());
+  beforeEach(() => fetchMock.resetMocks());
+
+  it("throw timeout exceeded", async () => {
+    fetchMock.mockResponseOnce(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(JSON.stringify({ body: "ok" })), 300)
+        )
+    );
+
+    try {
+      await get("http://localhost:5000/todos/1", {
+        timeout: 100,
+      });
+      expect(true).toBeFalsy();
+    } catch (error) {
+      expect(error.message).toEqual("The operation was aborted. ");
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "outDir": "./dist",
-    "lib": ["dom", "ES2022"],
+    "lib": ["dom", "ES2022"]
   },
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
🚀 feat(request.ts): add timeout support to NordusRequest
📝 docs(README.md): add example of how to use timeout in requests 🧪 test(timeout.spec.ts): add test for timeout feature The NordusRequest class now supports a timeout feature that allows the user to specify a time in milliseconds to wait before aborting the request. The timeout is set via the `timeout` property in the `NordusConfig` interface. An example of how to use the timeout feature is now included in the README.md file. A test for the timeout feature has been added to the test suite.